### PR TITLE
DeepSleepを使わないように戻した

### DIFF
--- a/5374gadget-M5Atom/5374gadget-M5Atom.ino
+++ b/5374gadget-M5Atom/5374gadget-M5Atom.ino
@@ -69,19 +69,6 @@ void setup() {
   Serial.begin(115200);
   Serial.println("");
 
-  pinMode(25, OUTPUT);
-
-  while(1){
-    Serial.println("0"); digitalWrite(25, 0); delay(500);
-    Serial.println("1"); digitalWrite(25, 1); delay(500);
-    Serial.println("0"); digitalWrite(25, 0); delay(500);
-    // https://lang-ship.com/blog/work/esp32-sleep-setting/
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH  , ESP_PD_OPTION_ON);
-    esp_sleep_enable_timer_wakeup(3000000);
-    Serial.println("going deep sleep..."); delay(1000);
-    esp_deep_sleep_start();
-  }
-
   // WiFi接続
   wifiConnect();
   delay(1000);

--- a/5374gadget-M5Atom/5374gadget-M5Atom.ino
+++ b/5374gadget-M5Atom/5374gadget-M5Atom.ino
@@ -69,6 +69,19 @@ void setup() {
   Serial.begin(115200);
   Serial.println("");
 
+  pinMode(25, OUTPUT);
+
+  while(1){
+    Serial.println("0"); digitalWrite(25, 0); delay(500);
+    Serial.println("1"); digitalWrite(25, 1); delay(500);
+    Serial.println("0"); digitalWrite(25, 0); delay(500);
+    // https://lang-ship.com/blog/work/esp32-sleep-setting/
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH  , ESP_PD_OPTION_ON);
+    esp_sleep_enable_timer_wakeup(3000000);
+    Serial.println("going deep sleep..."); delay(1000);
+    esp_deep_sleep_start();
+  }
+
   // WiFi接続
   wifiConnect();
   delay(1000);
@@ -172,14 +185,13 @@ void loop() {
 //https://lang-ship.com/blog/work/esp32-light-sleep/
   if (fLED == true) delay(100);
   else{
-//    delay(10000); // 10sec
     // light_sleepだとLEDが白点灯のことがあるのでいったんpendingし、deep_sleepから5分ごとに起こす (40mA程度)
-    esp_sleep_enable_timer_wakeup(10000000 * 30); // 10 sec * 6 * 5 = 5min
-    Serial.println("going deep sleep..."); delay(1000);
-    esp_deep_sleep_start();
-    
+    // →deep_sleepでも、一部LEDが白点灯になる（GPIO27がDeepSleep中にLに保持されないっぽ）ので、delay()に変更
+//    esp_sleep_enable_timer_wakeup(10000000 * 30); // 10 sec * 6 * 5 = 5min
+//    Serial.println("going deep sleep..."); delay(1000);
+//    esp_deep_sleep_start();
+    delay(300000); // 5min
   }
-
   M5.update();
 }
 


### PR DESCRIPTION
DeepSleep中に一部LEDが白点灯する現象がある。NeoPixelがつながっているGPIO27がDeepSleep中にLに保持されないのが原因と思われるが、解決策がわからないため、delay()で待機するように戻した。
ref: ESP32のDeepSleep：これによれば、DeepSleep中もGPIOの値は保持されるはずだが・・・
https://lang-ship.com/blog/work/esp32-sleep-setting/